### PR TITLE
Step 3. Inject Bundles via Antehandler [must be in mempool]

### DIFF
--- a/app/ante.go
+++ b/app/ante.go
@@ -16,6 +16,8 @@ import (
 	"github.com/sei-protocol/sei-chain/app/antedecorators/depdecorators"
 	evmante "github.com/sei-protocol/sei-chain/x/evm/ante"
 	evmkeeper "github.com/sei-protocol/sei-chain/x/evm/keeper"
+	mevante "github.com/sei-protocol/sei-chain/x/mev/ante"
+	mevkeeper "github.com/sei-protocol/sei-chain/x/mev/keeper"
 	"github.com/sei-protocol/sei-chain/x/oracle"
 	oraclekeeper "github.com/sei-protocol/sei-chain/x/oracle/keeper"
 )
@@ -33,7 +35,7 @@ type HandlerOptions struct {
 	EVMKeeper           *evmkeeper.Keeper
 	TXCounterStoreKey   sdk.StoreKey
 	LatestCtxGetter     func() sdk.Context
-	MEVKeeper           *mevkeeper.Keeper // Add this line
+	MevKeeper           *mevkeeper.Keeper
 
 	TracingInfo *tracing.Info
 }
@@ -92,7 +94,7 @@ func NewAnteHandlerAndDepGenerator(options HandlerOptions) (sdk.AnteHandler, sdk
 		sdk.DefaultWrappedAnteDecorator(ante.NewValidateMemoDecorator(options.AccountKeeper)),
 		ante.NewConsumeGasForTxSizeDecorator(options.AccountKeeper),
 		// Add MEV decorator here, before PriorityDecorator
-		sdk.DefaultWrappedAnteDecorator(mevante.NewMEVDecorator(options.MevKeeper)),
+		sdk.DefaultWrappedAnteDecorator(mevante.NewMEVDecorator(*options.MevKeeper)),
 		// PriorityDecorator must be called after DeductFeeDecorator which sets tx priority based on tx fees
 		sdk.DefaultWrappedAnteDecorator(antedecorators.NewPriorityDecorator()),
 		// SetPubKeyDecorator must be called before all signature verification decorators

--- a/app/ante.go
+++ b/app/ante.go
@@ -33,6 +33,7 @@ type HandlerOptions struct {
 	EVMKeeper           *evmkeeper.Keeper
 	TXCounterStoreKey   sdk.StoreKey
 	LatestCtxGetter     func() sdk.Context
+	MEVKeeper           *mevkeeper.Keeper // Add this line
 
 	TracingInfo *tracing.Info
 }
@@ -90,6 +91,8 @@ func NewAnteHandlerAndDepGenerator(options HandlerOptions) (sdk.AnteHandler, sdk
 		sdk.DefaultWrappedAnteDecorator(ante.NewTxTimeoutHeightDecorator()),
 		sdk.DefaultWrappedAnteDecorator(ante.NewValidateMemoDecorator(options.AccountKeeper)),
 		ante.NewConsumeGasForTxSizeDecorator(options.AccountKeeper),
+		// Add MEV decorator here, before PriorityDecorator
+		sdk.DefaultWrappedAnteDecorator(mevante.NewMEVDecorator(options.MevKeeper)),
 		// PriorityDecorator must be called after DeductFeeDecorator which sets tx priority based on tx fees
 		sdk.DefaultWrappedAnteDecorator(antedecorators.NewPriorityDecorator()),
 		// SetPubKeyDecorator must be called before all signature verification decorators

--- a/app/ante_test.go
+++ b/app/ante_test.go
@@ -102,6 +102,7 @@ func (suite *AnteTestSuite) SetupTest(isCheckTx bool) {
 			AccessControlKeeper: &suite.App.AccessControlKeeper,
 			TracingInfo:         tracingInfo,
 			EVMKeeper:           &suite.App.EvmKeeper,
+			MevKeeper:          &suite.App.MevKeeper,
 			LatestCtxGetter:     func() sdk.Context { return suite.Ctx },
 		},
 	)

--- a/app/antedecorators/priority.go
+++ b/app/antedecorators/priority.go
@@ -10,6 +10,7 @@ import (
 const (
 	OraclePriority       = math.MaxInt64 - 100
 	EVMAssociatePriority = math.MaxInt64 - 101
+	MEVBundlePriority    = math.MaxInt64 - 102
 	// This is the max priority a non oracle or associate tx can take
 	MaxPriority = math.MaxInt64 - 1000
 )

--- a/app/app.go
+++ b/app/app.go
@@ -927,6 +927,7 @@ func New(
 			EVMKeeper:           &app.EvmKeeper,
 			TracingInfo:         app.GetBaseApp().TracingInfo,
 			AccessControlKeeper: &app.AccessControlKeeper,
+			MEVKeeper          *mevkeeper.Keeper  // Add this line
 			LatestCtxGetter: func() sdk.Context {
 				return app.GetCheckCtx()
 			},

--- a/app/app.go
+++ b/app/app.go
@@ -927,7 +927,7 @@ func New(
 			EVMKeeper:           &app.EvmKeeper,
 			TracingInfo:         app.GetBaseApp().TracingInfo,
 			AccessControlKeeper: &app.AccessControlKeeper,
-			MEVKeeper          *mevkeeper.Keeper  // Add this line
+			MevKeeper:          &app.MevKeeper,  // Fixed syntax
 			LatestCtxGetter: func() sdk.Context {
 				return app.GetCheckCtx()
 			},

--- a/x/mev/ante/priority.go
+++ b/x/mev/ante/priority.go
@@ -1,0 +1,36 @@
+package ante
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/sei-protocol/sei-chain/app/antedecorators"
+	"github.com/sei-protocol/sei-chain/x/mev/keeper"
+)
+
+type MEVDecorator struct {
+	mevKeeper keeper.Keeper
+}
+
+func NewMEVDecorator(mk keeper.Keeper) MEVDecorator {
+	return MEVDecorator{
+		mevKeeper: mk,
+	}
+}
+
+func (md MEVDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
+	currentHeight := uint64(ctx.BlockHeight())
+	bundle := md.mevKeeper.GetNextBundle(ctx, currentHeight)
+
+	if bundle != nil {
+		// Check if this tx is in the bundle
+		currentTxBytes := ctx.TxBytes()
+		for i, bundledTx := range bundle.Txs {
+			if bundledTx == string(currentTxBytes) {
+				// Set descending priorities for bundle txs to maintain order
+				bundlePriority := antedecorators.MEVBundlePriority - int64(i)
+				return ctx.WithPriority(bundlePriority), next(ctx, tx, simulate)
+			}
+		}
+	}
+
+	return next(ctx, tx, simulate)
+}

--- a/x/mev/ante/priority.go
+++ b/x/mev/ante/priority.go
@@ -27,7 +27,8 @@ func (md MEVDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, nex
 			if bundledTx == string(currentTxBytes) {
 				// Set descending priorities for bundle txs to maintain order
 				bundlePriority := antedecorators.MEVBundlePriority - int64(i)
-				return ctx.WithPriority(bundlePriority), next(ctx, tx, simulate)
+				newCtx := ctx.WithPriority(bundlePriority)
+				return next(newCtx, tx, simulate)
 			}
 		}
 	}

--- a/x/mev/keeper/end_block.go
+++ b/x/mev/keeper/end_block.go
@@ -1,0 +1,11 @@
+package keeper
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	abci "github.com/tendermint/tendermint/abci/types"
+)
+
+func (k Keeper) EndBlock(ctx sdk.Context) []abci.ValidatorUpdate {
+	k.CleanupProcessedBundles(ctx)
+	return []abci.ValidatorUpdate{}
+}

--- a/x/mev/keeper/keeper.go
+++ b/x/mev/keeper/keeper.go
@@ -40,3 +40,38 @@ func (k Keeper) SubmitBundle(ctx sdk.Context, msg *types.MsgSubmitBundle) (*type
 		Success: true,
 	}, nil
 }
+
+func (k Keeper) GetNextBundle(ctx sdk.Context, blockHeight uint64) *types.Bundle {
+	store := ctx.KVStore(k.storeKey)
+
+	var nextBundle *types.Bundle
+	iterator := sdk.KVStorePrefixIterator(store, []byte("bundle"))
+	defer iterator.Close()
+
+	for ; iterator.Valid(); iterator.Next() {
+		var bundle types.Bundle
+		k.cdc.MustUnmarshal(iterator.Value(), &bundle)
+		if bundle.BlockNum == blockHeight {
+			nextBundle = &bundle
+			break
+		}
+	}
+
+	return nextBundle
+}
+
+func (k Keeper) CleanupProcessedBundles(ctx sdk.Context) {
+	store := ctx.KVStore(k.storeKey)
+	currentHeight := uint64(ctx.BlockHeight())
+
+	iterator := sdk.KVStorePrefixIterator(store, []byte("bundle"))
+	defer iterator.Close()
+
+	for ; iterator.Valid(); iterator.Next() {
+		var bundle types.Bundle
+		k.cdc.MustUnmarshal(iterator.Value(), &bundle)
+		if bundle.BlockNum <= currentHeight {
+			store.Delete(iterator.Key())
+		}
+	}
+}

--- a/x/mev/module.go
+++ b/x/mev/module.go
@@ -151,8 +151,8 @@ func (AppModule) ConsensusVersion() uint64 { return 1 }
 func (AppModule) BeginBlock(_ sdk.Context, _ abci.RequestBeginBlock) {}
 
 // EndBlock returns the end blocker for the mev module.
-func (am AppModule) EndBlock(_ sdk.Context, _ abci.RequestEndBlock) []abci.ValidatorUpdate {
-	return []abci.ValidatorUpdate{}
+func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.ValidatorUpdate {
+	return am.keeper.EndBlock(ctx)
 }
 
 // RegisterServices registers module services.

--- a/x/mev/readme.md
+++ b/x/mev/readme.md
@@ -1,0 +1,4 @@
+# Mev Module!
+
+This allows users to submit bundles of transactions to the chain.
+


### PR DESCRIPTION
This injects bundles into the transaction processing flow. 

This will just treat bundles as normal transactions - no special priority will be given, they will just be unbundled and submitted in the flow on the blocks specified.
